### PR TITLE
[Test] Do not depend on kotlin-native-utils in Gradle plugin

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -39,8 +39,7 @@ ext.deps = [
             "core": "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinCoroutines}",
             "test": "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinCoroutines}"
         ],
-        reflect: "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}",
-        nativeUtils: "org.jetbrains.kotlin:kotlin-native-utils:${versions.kotlin}"
+        reflect: "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
     ],
     androidx: [
         test: [

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -25,7 +25,6 @@ tasks.named('pluginUnderTestMetadata').configure {
 dependencies {
   implementation project(':sqldelight-compiler')
   implementation project(':sqlite-migrations')
-  implementation deps.kotlin.nativeUtils
   implementation deps.sqlitePsi
   implementation deps.intellij.core
   implementation deps.intellij.java

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/SourceRoots.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/SourceRoots.kt
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import org.jetbrains.kotlin.konan.target.KonanTarget
 
 /**
  * @return A list of source roots and their dependencies.
@@ -95,7 +94,7 @@ private fun KotlinMultiplatformExtension.sources(project: Project): List<Source>
         }
         Source(
           type = target.platformType,
-          konanTarget = (target as? KotlinNativeTarget)?.konanTarget,
+          nativePresetName = (target as? KotlinNativeTarget)?.preset?.name,
           name = "${target.name}${compilation.name.capitalize()}",
           variantName = (compilation as? KotlinJvmAndroidCompilation)?.name,
           sourceDirectorySet = compilation.defaultSourceSet.kotlin,
@@ -157,7 +156,7 @@ private fun TaskContainer.namedOrNull(
 
 internal data class Source(
   val type: KotlinPlatformType,
-  val konanTarget: KonanTarget? = null,
+  val nativePresetName: String? = null,
   val sourceDirectorySet: SourceDirectorySet,
   val name: String,
   val variantName: String? = null,
@@ -172,7 +171,7 @@ internal data class Source(
 
     // Multiplatform native matched or android variants matched.
     matches = matches.filter {
-      konanTarget == it.konanTarget && variantName == it.variantName
+      nativePresetName == it.nativePresetName && variantName == it.variantName
     }
     return matches.singleOrNull()
   }


### PR DESCRIPTION
kotlin-native-utils.jar is an internal artifact published due to
technical reasons only. But now there is no need for it anymore
and its publication will be stopped.

This patch removes a dependency on this artifact. It also removes
usages of the KonanTarget class because this class is an internal
detail of the Kotlin compiler which can be changed at any moment.